### PR TITLE
fix: language switching, control grid and Framework Progress bugs

### DIFF
--- a/ui/auditnist-local.html
+++ b/ui/auditnist-local.html
@@ -121,7 +121,7 @@ class="absolute w-full bg-gray-800 border border-gray-600 rounded-lg mt-1 max-h-
 
 <!-- Visual Grid -->
 <div id="controls-visual-grid"
-class="container mx-auto mt-4 grid grid-cols-4 md:grid-cols-8 gap-2">
+class="hidden container mx-auto mt-4 grid grid-cols-4 md:grid-cols-8 gap-2">
 </div>
 
 <!-- Suggest Controls -->
@@ -626,7 +626,24 @@ return this.store[scfId]?.evaluations || [];
 // 🔹 UI FUNCTIONS
 // ─────────────────────────────────────────────────────────────────────────────
 function showGridPreview() {
-// Grid is always visible — no-op kept for backwards compatibility
+const grid = document.getElementById('controls-visual-grid');
+grid.classList.remove('hidden');
+if (gridTimeout) clearTimeout(gridTimeout);
+gridTimeout = setTimeout(() => { grid.classList.add('hidden'); }, 5000);
+}
+
+function addControlFromGrid(scfId, fwCode, name) {
+// Don't add if already in workspace
+const existing = [...document.querySelectorAll('.ctrl')].find(el => el.dataset.scfId === scfId);
+if (existing) {
+existing.closest('.control').scrollIntoView({ behavior: 'smooth', block: 'center' });
+return;
+}
+const scfControl = scfData?.controls.find(c => c.id === scfId);
+const question = scfControl?.question || '';
+const vertical = scfControl?.verticals?.[0] || '';
+addControl(false, question, scfId, fwCode, name, vertical);
+document.getElementById('controls').lastElementChild?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 }
 
 function changeFramework() {
@@ -877,6 +894,7 @@ controlBlock.classList.add('border-cyberok', 'opacity-90');
 controlBlock.querySelector('.ctrl').classList.add('text-cyberok');
 
 renderControlGrid();
+updateFrameworkProgressBars();
 }
 isDirty = true;
 }
@@ -939,7 +957,9 @@ statusIcon = '⚠️';
 return `
 <div class="ctrl-box text-xs p-2 rounded border border-gray-600 ${statusClass} cursor-pointer relative"
 data-scf-id="${c.id}"
-data-fw-code="${fwCode}">
+data-fw-code="${fwCode}"
+title="${c.name}"
+onclick="addControlFromGrid('${c.id}','${fwCode}','${c.name.replace(/'/g,'&#39;')}')">
 <div class="font-bold">${fwCode}</div>
 <div class="text-[10px] opacity-70 truncate">${c.name}</div>
 <div class="absolute top-1 right-1 text-[10px]">${statusIcon}</div>
@@ -2017,6 +2037,7 @@ window.changeFramework = changeFramework;
 window.removeControl = removeControl;
 window.onComplianceChange = onComplianceChange;
 window.showGridPreview = showGridPreview;
+window.addControlFromGrid = addControlFromGrid;
 window.addEventListener('beforeunload', function (e) {
   if (isDirty) {
     e.preventDefault();


### PR DESCRIPTION
## Bug Fixes

### 1. Language switching broken for 5 languages
After the architecture consolidation commit, the `TRANSLATIONS` object was reduced to only `es` and `en`. Switching to French, German, Portuguese, Arabic, or Chinese silently fell back to Spanish.
- Restored all 7 languages with complete key sets

### 2. New UI sections not translating
All elements added in the latest refactor (Dashboard KPIs, search bar, Historial button, Export/Import JSON, chart titles, summary stats) had no `data-i18n` attributes and were permanently hardcoded in Spanish.
- Added `data-i18n` / `data-i18n-placeholder` to all affected elements

### 3. Template Library modal not translating
Modal title, search placeholder, Select All, Load Selected buttons, and vertical tab labels (General, Healthcare, Finance…) were hardcoded and unaffected by language changes.
- Added `data-i18n` to static elements
- Replaced hardcoded `VERTICAL_META` label strings with `T(labelKey)` calls rendered at runtime
- Added `renderVerticalTabs()` call inside `setLanguage()` so tabs re-render live

### 4. Control block labels not translating
STATUS, RISK, AUDIT QUESTION, AUDITOR NOTES, EVIDENCE labels inside `addControl()` were hardcoded strings in the template literal, so controls added after a language switch always rendered in Spanish.
- Replaced all hardcoded strings with `T()` calls

### 5. Clicking control grid cells did nothing
Grid cells had `cursor-pointer` but no click handler. Added `addControlFromGrid()` which loads the clicked SCF control into the audit workspace (or scrolls to it if already added).

### 6. Framework Progress bars not updating
`onComplianceChange()` was calling `renderControlGrid()` and `EvaluationRegistry.save()` but never `updateFrameworkProgressBars()`. Progress bars stayed at 0% regardless of evaluations.
- Added `updateFrameworkProgressBars()` call to `onComplianceChange()`
