### PR TITLE
feat(models): implement Control, Evaluation and AuditSession data models

### DIFF
--- a/models/auditSession.js
+++ b/models/auditSession.js
@@ -2,33 +2,77 @@
  * ---------------------------------------------------------
  * AuditNIST Pro — Audit Session Model
  * ---------------------------------------------------------
- * Defines the structure of a complete audit session.
- *
- * This model represents the full audit lifecycle including:
- * - Metadata
- * - Framework selection
- * - Controls evaluated
- * - Risk summary
- * - Audit timestamps
- *
- * Expected structure:
- *
- * {
- *   id: string,
- *   metadata: {
- *     company,
- *     auditor,
- *     scope,
- *     date
- *   },
- *   frameworkKey: string,
- *   controls: [],
- *   createdAt: Date,
- *   updatedAt: Date,
- *   summary: {},
- *   derivedRiskScore: number
- * }
- *
- * Placeholder for future modular architecture.
+ * Represents a complete audit session including metadata,
+ * framework selection, controls, and derived summary.
+ * Exposes window.AuditSession for use in auditnist-local.html.
  * ---------------------------------------------------------
  */
+
+export class AuditSession {
+  constructor({
+    id        = '',
+    empresa   = '',
+    auditora  = '',
+    auditor   = '',
+    alcance   = '',
+    fecha     = '',
+    framework = 'nist-csf'
+  } = {}) {
+    this.id        = id || `AUD-${Date.now()}`;
+    this.empresa   = empresa;
+    this.auditora  = auditora;
+    this.auditor   = auditor;
+    this.alcance   = alcance;
+    this.fecha     = fecha || new Date().toLocaleDateString();
+    this.framework = framework;
+    this.controls  = [];
+    this.createdAt = Date.now();
+    this.updatedAt = Date.now();
+  }
+
+  addControl(control) {
+    this.controls.push(control);
+    this.updatedAt = Date.now();
+  }
+
+  /**
+   * Returns compliance and risk summary across all controls.
+   * Counts unique controls — not evaluations.
+   */
+  getSummary() {
+    const total        = this.controls.length;
+    const compliant    = this.controls.filter(c => c.compliance === 'yes').length;
+    const partial      = this.controls.filter(c => c.compliance === 'partial').length;
+    const nonCompliant = this.controls.filter(c => c.compliance === 'no').length;
+    const highRisk     = this.controls.filter(c => c.risk === 'high').length;
+    const evaluated    = this.controls.filter(c => c.compliance !== '').length;
+    return { total, evaluated, compliant, partial, nonCompliant, highRisk };
+  }
+
+  toJSON() {
+    return {
+      id:        this.id,
+      empresa:   this.empresa,
+      auditora:  this.auditora,
+      auditor:   this.auditor,
+      alcance:   this.alcance,
+      fecha:     this.fecha,
+      framework: this.framework,
+      controls:  this.controls.map(c => c.toJSON ? c.toJSON() : c),
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt
+    };
+  }
+
+  static fromJSON(data = {}) {
+    const session    = new AuditSession(data);
+    session.controls = (data.controls || []).map(c =>
+      window.Control ? window.Control.fromJSON(c) : c
+    );
+    session.createdAt = data.createdAt ?? Date.now();
+    session.updatedAt = data.updatedAt ?? Date.now();
+    return session;
+  }
+}
+
+window.AuditSession = AuditSession;

--- a/models/control.js
+++ b/models/control.js
@@ -2,30 +2,94 @@
  * ---------------------------------------------------------
  * AuditNIST Pro — Control Model
  * ---------------------------------------------------------
- * Defines the structure of a control within an audit session.
- *
- * A control represents an individual requirement from
- * a cybersecurity framework such as:
- * - NIST CSF
- * - ISO 27001
- * - CIS Controls
- * - COBIT
- *
- * Expected structure:
- *
- * {
- *   id: string,
- *   frameworkCode: string,
- *   title: string,
- *   question: string,
- *   domain: string,
- *   category: string,
- *   vertical: string,
- *   evaluation: {},
- *   evidence: string,
- *   notes: string
- * }
- *
- * Placeholder for future modular architecture.
+ * Represents a single audit control with validation.
+ * Exposes window.Control for use in auditnist-local.html.
  * ---------------------------------------------------------
  */
+
+export class Control {
+  static VALID_COMPLIANCE = ['yes', 'no', 'partial', ''];
+  static VALID_RISK       = ['high', 'medium', 'low', ''];
+
+  constructor({ scfId = '', fwCode = '', name = '', question = '', vertical = '', guidance = '' } = {}) {
+    this.scfId      = scfId;
+    this.fwCode     = fwCode;
+    this.name       = name;
+    this.question   = question;
+    this.vertical   = vertical;
+    this.guidance   = guidance;
+    this.compliance = '';
+    this.risk       = '';
+    this.evidence   = '';
+    this.notes      = '';
+    this.createdAt  = Date.now();
+    this.updatedAt  = Date.now();
+  }
+
+  setCompliance(value) {
+    const v = (value ?? '').toString();
+    if (!Control.VALID_COMPLIANCE.includes(v))
+      throw new Error(`Invalid compliance "${v}". Expected: ${Control.VALID_COMPLIANCE.filter(Boolean).join('|')}`);
+    this.compliance = v;
+    this.updatedAt  = Date.now();
+    return this;
+  }
+
+  setRisk(value) {
+    const v = (value ?? '').toString();
+    if (!Control.VALID_RISK.includes(v))
+      throw new Error(`Invalid risk "${v}". Expected: ${Control.VALID_RISK.filter(Boolean).join('|')}`);
+    this.risk      = v;
+    this.updatedAt = Date.now();
+    return this;
+  }
+
+  setEvidence(text) { this.evidence = String(text ?? ''); this.updatedAt = Date.now(); return this; }
+  setNotes(text)    { this.notes    = String(text ?? ''); this.updatedAt = Date.now(); return this; }
+
+  isEvaluated() { return this.compliance !== ''; }
+  isCompliant()  { return this.compliance === 'yes'; }
+  isPartial()    { return this.compliance === 'partial'; }
+
+  toJSON() {
+    return {
+      scfId:      this.scfId,
+      fwCode:     this.fwCode,
+      name:       this.name,
+      question:   this.question,
+      vertical:   this.vertical,
+      compliance: this.compliance,
+      risk:       this.risk,
+      evidence:   this.evidence,
+      notes:      this.notes,
+      createdAt:  this.createdAt,
+      updatedAt:  this.updatedAt
+    };
+  }
+
+  static fromJSON(data = {}) {
+    const c        = new Control(data);
+    c.compliance   = data.compliance ?? '';
+    c.risk         = data.risk       ?? '';
+    c.evidence     = data.evidence   ?? '';
+    c.notes        = data.notes      ?? '';
+    c.createdAt    = data.createdAt  ?? Date.now();
+    c.updatedAt    = data.updatedAt  ?? Date.now();
+    return c;
+  }
+
+  /**
+   * Returns an array of validation error strings.
+   * Empty array means valid.
+   */
+  static validate(data = {}) {
+    const errors = [];
+    if (data.compliance !== undefined && !Control.VALID_COMPLIANCE.includes(data.compliance))
+      errors.push(`compliance must be: ${Control.VALID_COMPLIANCE.filter(Boolean).join('|')}`);
+    if (data.risk !== undefined && !Control.VALID_RISK.includes(data.risk))
+      errors.push(`risk must be: ${Control.VALID_RISK.filter(Boolean).join('|')}`);
+    return errors;
+  }
+}
+
+window.Control = Control;

--- a/models/evaluation.js
+++ b/models/evaluation.js
@@ -2,25 +2,81 @@
  * ---------------------------------------------------------
  * AuditNIST Pro — Evaluation Model
  * ---------------------------------------------------------
- * Defines the evaluation result of a control.
- *
- * This model captures the auditor's assessment including:
- * - Compliance status
- * - Risk level
- * - Evidence
- * - Notes
- *
- * Expected structure:
- *
- * {
- *   compliance: string,   // compliant | partial | noncompliant
- *   risk: string,         // low | medium | high
- *   evidence: string,
- *   notes: string,
- *   evaluatedAt: Date,
- *   evaluatedBy: string
- * }
- *
- * Placeholder for future modular architecture.
+ * Represents the auditor's assessment of a single control.
+ * Enforces valid compliance and risk values at construction.
+ * Exposes window.Evaluation for use in auditnist-local.html.
  * ---------------------------------------------------------
  */
+
+export class Evaluation {
+  static VALID_COMPLIANCE = ['yes', 'no', 'partial'];
+  static VALID_RISK       = ['high', 'medium', 'low', ''];
+
+  constructor({
+    scfId,
+    auditId,
+    compliance,
+    risk       = '',
+    evidence   = '',
+    notes      = '',
+    company    = '',
+    auditor    = '',
+    vertical   = ''
+  } = {}) {
+    const errors = Evaluation.validate({ scfId, auditId, compliance, risk });
+    if (errors.length) throw new Error(errors.join('; '));
+
+    this.scfId      = scfId;
+    this.auditId    = auditId;
+    this.compliance = compliance;
+    this.risk       = risk;
+    this.evidence   = String(evidence ?? '');
+    this.notes      = String(notes    ?? '');
+    this.company    = company;
+    this.auditor    = auditor;
+    this.vertical   = vertical;
+    this.timestamp  = Date.now();
+  }
+
+  isCompliant() { return this.compliance === 'yes'; }
+  isPartial()   { return this.compliance === 'partial'; }
+  isHighRisk()  { return this.risk === 'high'; }
+
+  toJSON() {
+    return {
+      scfId:      this.scfId,
+      auditId:    this.auditId,
+      compliance: this.compliance,
+      risk:       this.risk,
+      evidence:   this.evidence,
+      notes:      this.notes,
+      company:    this.company,
+      auditor:    this.auditor,
+      vertical:   this.vertical,
+      timestamp:  this.timestamp
+    };
+  }
+
+  static fromJSON(data = {}) {
+    return new Evaluation(data);
+  }
+
+  /**
+   * Returns an array of validation error strings.
+   * Empty array means valid.
+   */
+  static validate(data = {}) {
+    const errors = [];
+    if (!data.scfId)
+      errors.push('scfId is required');
+    if (!data.auditId)
+      errors.push('auditId is required');
+    if (!Evaluation.VALID_COMPLIANCE.includes(data.compliance))
+      errors.push(`compliance must be: ${Evaluation.VALID_COMPLIANCE.join('|')}`);
+    if (data.risk && !Evaluation.VALID_RISK.includes(data.risk))
+      errors.push(`risk must be: ${Evaluation.VALID_RISK.filter(Boolean).join('|')}`);
+    return errors;
+  }
+}
+
+window.Evaluation = Evaluation;

--- a/ui/auditnist-local.html
+++ b/ui/auditnist-local.html
@@ -21,6 +21,70 @@ cyberevil: '#ef4444', cyberwarn: '#facc15', cyberok: '#22c55e'
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
+<script>
+// ─────────────────────────────────────────────────────────────────────────────
+// Control Data Models — validation layer (mirrors models/control.js etc.)
+// ─────────────────────────────────────────────────────────────────────────────
+class Control {
+  static VALID_COMPLIANCE = ['yes', 'no', 'partial', ''];
+  static VALID_RISK       = ['high', 'medium', 'low', ''];
+
+  constructor({ scfId='', fwCode='', name='', question='', vertical='', guidance='' } = {}) {
+    this.scfId=scfId; this.fwCode=fwCode; this.name=name;
+    this.question=question; this.vertical=vertical; this.guidance=guidance;
+    this.compliance=''; this.risk=''; this.evidence=''; this.notes='';
+    this.createdAt=Date.now(); this.updatedAt=Date.now();
+  }
+  setCompliance(v){ v=(v??'').toString(); if(!Control.VALID_COMPLIANCE.includes(v)) throw new Error(`Invalid compliance "${v}"`); this.compliance=v; this.updatedAt=Date.now(); return this; }
+  setRisk(v){ v=(v??'').toString(); if(!Control.VALID_RISK.includes(v)) throw new Error(`Invalid risk "${v}"`); this.risk=v; this.updatedAt=Date.now(); return this; }
+  setEvidence(t){ this.evidence=String(t??''); this.updatedAt=Date.now(); return this; }
+  setNotes(t)   { this.notes=String(t??'');    this.updatedAt=Date.now(); return this; }
+  isEvaluated(){ return this.compliance!==''; }
+  isCompliant() { return this.compliance==='yes'; }
+  isPartial()   { return this.compliance==='partial'; }
+  toJSON(){ return {scfId:this.scfId,fwCode:this.fwCode,name:this.name,question:this.question,vertical:this.vertical,compliance:this.compliance,risk:this.risk,evidence:this.evidence,notes:this.notes,createdAt:this.createdAt,updatedAt:this.updatedAt}; }
+  static fromJSON(d={}){ const c=new Control(d); c.compliance=d.compliance??''; c.risk=d.risk??''; c.evidence=d.evidence??''; c.notes=d.notes??''; c.createdAt=d.createdAt??Date.now(); c.updatedAt=d.updatedAt??Date.now(); return c; }
+  static validate(d={}){ const e=[]; if(d.compliance!==undefined&&!Control.VALID_COMPLIANCE.includes(d.compliance)) e.push(`compliance must be: ${Control.VALID_COMPLIANCE.filter(Boolean).join('|')}`); if(d.risk!==undefined&&!Control.VALID_RISK.includes(d.risk)) e.push(`risk must be: ${Control.VALID_RISK.filter(Boolean).join('|')}`); return e; }
+}
+
+class Evaluation {
+  static VALID_COMPLIANCE = ['yes', 'no', 'partial'];
+  static VALID_RISK       = ['high', 'medium', 'low', ''];
+
+  constructor({ scfId, auditId, compliance, risk='', evidence='', notes='', company='', auditor='', vertical='' }={}) {
+    const errs = Evaluation.validate({ scfId, auditId, compliance, risk });
+    if (errs.length) throw new Error(errs.join('; '));
+    this.scfId=scfId; this.auditId=auditId; this.compliance=compliance; this.risk=risk;
+    this.evidence=String(evidence??''); this.notes=String(notes??'');
+    this.company=company; this.auditor=auditor; this.vertical=vertical; this.timestamp=Date.now();
+  }
+  isCompliant(){ return this.compliance==='yes'; }
+  isPartial()  { return this.compliance==='partial'; }
+  isHighRisk() { return this.risk==='high'; }
+  toJSON(){ return {scfId:this.scfId,auditId:this.auditId,compliance:this.compliance,risk:this.risk,evidence:this.evidence,notes:this.notes,company:this.company,auditor:this.auditor,vertical:this.vertical,timestamp:this.timestamp}; }
+  static fromJSON(d={}){ return new Evaluation(d); }
+  static validate(d={}){ const e=[]; if(!d.scfId) e.push('scfId is required'); if(!d.auditId) e.push('auditId is required'); if(!Evaluation.VALID_COMPLIANCE.includes(d.compliance)) e.push(`compliance must be: ${Evaluation.VALID_COMPLIANCE.join('|')}`); if(d.risk&&!Evaluation.VALID_RISK.includes(d.risk)) e.push(`risk must be: ${Evaluation.VALID_RISK.filter(Boolean).join('|')}`); return e; }
+}
+
+class AuditSession {
+  constructor({ id='', empresa='', auditora='', auditor='', alcance='', fecha='', framework='nist-csf' }={}) {
+    this.id=id||`AUD-${Date.now()}`; this.empresa=empresa; this.auditora=auditora;
+    this.auditor=auditor; this.alcance=alcance; this.fecha=fecha||new Date().toLocaleDateString();
+    this.framework=framework; this.controls=[]; this.createdAt=Date.now(); this.updatedAt=Date.now();
+  }
+  addControl(c){ this.controls.push(c); this.updatedAt=Date.now(); }
+  getSummary(){
+    const total=this.controls.length, compliant=this.controls.filter(c=>c.compliance==='yes').length,
+          partial=this.controls.filter(c=>c.compliance==='partial').length,
+          nonCompliant=this.controls.filter(c=>c.compliance==='no').length,
+          highRisk=this.controls.filter(c=>c.risk==='high').length,
+          evaluated=this.controls.filter(c=>c.compliance!=='').length;
+    return {total,evaluated,compliant,partial,nonCompliant,highRisk};
+  }
+  toJSON(){ return {id:this.id,empresa:this.empresa,auditora:this.auditora,auditor:this.auditor,alcance:this.alcance,fecha:this.fecha,framework:this.framework,controls:this.controls.map(c=>c.toJSON?c.toJSON():c),createdAt:this.createdAt,updatedAt:this.updatedAt}; }
+  static fromJSON(d={}){ const s=new AuditSession(d); s.controls=(d.controls||[]).map(c=>Control.fromJSON(c)); s.createdAt=d.createdAt??Date.now(); s.updatedAt=d.updatedAt??Date.now(); return s; }
+}
+</script>
 </head>
 <body class="bg-cyberbg text-gray-100 font-mono min-h-screen flex flex-col">
 
@@ -881,6 +945,9 @@ company: document.getElementById('empresa_auditada').value || 'N/A',
 auditor: document.getElementById('auditor').value || 'N/A'
 };
 
+const _cvErrs = Evaluation.validate({ scfId, auditId: auditContext.auditId, compliance: select.value, risk: controlBlock.querySelector('.riesgo')?.value || '' });
+if (_cvErrs.length) console.warn('[Control Model] onComplianceChange validation:', _cvErrs);
+
 EvaluationRegistry.save(scfId, {
 scfId: scfId,
 compliance: select.value,
@@ -1250,7 +1317,9 @@ const ctrlsContainer = document.getElementById('controls');
 while (ctrlsContainer.firstChild) ctrlsContainer.removeChild(ctrlsContainer.firstChild);
 
 data.controls?.forEach(c => {
-addControl(false, c.question || '', c.scfId || '', '', c.ctrl.split(' – ')[1] || '', '');
+const _impErrs = Control.validate({ compliance: c.cumple, risk: c.riesgo });
+if (_impErrs.length) console.warn(`[Control Model] importFromJSON validation for "${c.ctrl}":`, _impErrs);
+addControl(false, c.question || '', c.scfId || '', '', (c.ctrl || '').split(' – ')[1] || c.ctrl || '', '');
 const wrapper = document.querySelectorAll('.control')[document.querySelectorAll('.control').length - 1];
 wrapper.querySelector('.cumple').value = c.cumple || '';
 wrapper.querySelector('.riesgo').addEventListener('change', (e) => {
@@ -1635,6 +1704,9 @@ function onRiskChange(select) {
     company: document.getElementById('empresa_auditada').value || 'N/A',
     auditor: document.getElementById('auditor').value || 'N/A'
   };
+
+  const _rvErrs = Evaluation.validate({ scfId, auditId: auditContext.auditId, compliance: cumple, risk: select.value });
+  if (_rvErrs.length) console.warn('[Control Model] onRiskChange validation:', _rvErrs);
 
   EvaluationRegistry.save(scfId, {
     scfId: scfId,


### PR DESCRIPTION
## Summary

Closes #12 - implements the structured data model layer proposed in the Level 2 roadmap (Issue #11).

## What changed

### models/control.js
Replaces the comment stub with a full Control class:
- Validates compliance values (yes|no|partial) and risk values (high|medium|low) via setCompliance()/setRisk() setters
- static validate(data) returns an array of error strings, empty if valid
- static fromJSON(data) / toJSON() for round-trip serialization
- isEvaluated(), isCompliant(), isPartial() helper methods

### models/evaluation.js
Replaces the comment stub with a full Evaluation class:
- Throws at construction if scfId, auditId, or compliance are missing/invalid
- static validate(data) for pre-construction checks
- isCompliant(), isPartial(), isHighRisk() helpers
- Full toJSON() / static fromJSON() support

### models/auditSession.js
Replaces the comment stub with a full AuditSession class:
- getSummary() counts unique controls (not evaluations), including partial - fixing the counting gap identified in the analysis
- addControl(), toJSON(), static fromJSON()

### ui/auditnist-local.html
- Inline copies of all three classes added to head for file:// compatibility
- Validation guards added at three data entry points without changing existing DOM or storage flow:
  - onComplianceChange() - validates before EvaluationRegistry.save()
  - onRiskChange() - validates before EvaluationRegistry.save()
  - importFromJSON() - validates each control on import; also fixes brittle c.ctrl.split crash when ctrl is undefined
- Invalid values log a console.warn with [Control Model] prefix - no blocking of existing behaviour

## Test plan

- [ ] Open http://localhost:8080/ui/auditnist-local.html
- [ ] Open DevTools console - confirm zero errors on page load
- [ ] Run in console: Control.validate({ compliance: "yes", risk: "high" }) -> []
- [ ] Run: Control.validate({ compliance: "bad" }) -> ["compliance must be: yes|no|partial"]
- [ ] Run: new Evaluation({ scfId: "AC-01", auditId: "x", compliance: "bad" }) -> throws
- [ ] Add controls via Template Library -> set compliance/risk -> no console errors
- [ ] Export to JSON -> re-import -> all controls restored correctly
- [ ] Save progress -> reload page -> load audit -> all values intact
