### PR TITLE
fix(m1): persist issued state, keep custom-control findings, align finding IDs

### DIFF
--- a/ui/auditnist-local.html
+++ b/ui/auditnist-local.html
@@ -2324,6 +2324,16 @@ function issueFinalReport() {
   data.publishedAt = new Date().toISOString();
   data.engagement.status = 'issued';
 
+  // The issued state must live in the app, not only in the downloaded file.
+  // Without this the status selector still reads its previous value, so the
+  // next saveProgress()/exportToJSON() would silently write the audit back to
+  // 'draft' and contradict a report that has already been issued. M4 locking
+  // will key off this persisted state.
+  const statusEl = document.getElementById('eng_status');
+  if (statusEl) statusEl.value = 'issued';
+  localStorage.setItem(`auditnist_${data.id}`, JSON.stringify(data));
+  isDirty = false;
+
   // Create and download the JSON file with findings
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
   saveAs(blob, `Audit_${currentFramework.toUpperCase()}_${data.id}_FINAL.json`);
@@ -2338,7 +2348,6 @@ function issueFinalReport() {
 // Priority Scoring Engine (compartido con el Hub)
 const IMPACT_SCORES = { critical: 10, high: 7, medium: 4, low: 2 };
 const EFFORT_SCORES = { low: 1, medium: 2, high: 3 };
-const COST_LABELS = { low: '$', medium: '$$', high: '$$$' };
 const DEFAULT_TIMEFRAMES = { critical: 15, high: 30, medium: 60, low: 90 };
 
 function estimateEffort(control) {
@@ -2362,11 +2371,17 @@ function calculateScore(control) {
 /**
  * Builds a STABLE ID for a finding.
  * Does NOT include auditId so the ID survives re-audits.
+ *
+ * Controls added manually (via "+ Add Control") carry no scfId, so they fall
+ * back to their framework code / name. That keeps custom controls addressable
+ * instead of dropping them, and keeps the id stable across re-issues.
+ * The Remediation Hub mirrors this formula so both sides derive the same id.
  */
 function buildFindingId(control) {
-    const scfId = control.scfId || control.id || 'UNKNOWN';
     const framework = currentFramework || 'nist-csf';
-    const normalizedKey = (scfId + '-' + framework).replace(/[^a-zA-Z0-9]/g, '_').toUpperCase();
+    const scfId = control.scfId || control.id || '';
+    const key = scfId || `CUSTOM-${control.fwCode || control.name || control.ctrl || 'UNKNOWN'}`;
+    const normalizedKey = (key + '-' + framework).replace(/[^a-zA-Z0-9]/g, '_').toUpperCase();
     return `FND-${normalizedKey}`;
 }
 
@@ -2375,9 +2390,12 @@ function buildFindingId(control) {
  * Follows the M0 lifecycle convention ("born with history").
  */
 function buildFinding(control, auditId) {
-        // ✅ FIX: Ignorar controles sin scfId (evita findings fantasma)
-    if (!control.scfId || control.scfId === '') return null;
-    
+    // Skip only controls with no identity at all (avoids phantom findings from
+    // empty rows). A manually added control has no scfId but still has a code
+    // or name, so it must produce a finding rather than be silently dropped.
+    const hasIdentity = control.scfId || control.fwCode || control.name || control.ctrl;
+    if (!hasIdentity) return null;
+
     const scfId = control.scfId || control.id || '';
     const controlCode = control.fwCode || scfId;
     const controlName = control.name || control.ctrl || '';
@@ -2423,9 +2441,9 @@ function buildFinding(control, auditId) {
         reason: reason,
         evidence: evidence,
         // ── PRIORITY SCORING (Innovación) ──
-        effort: effort,                      // ✅ low/medium/high
-        cost: effort,                        // ✅ $/$$/$$$
-        score: score,                        // ✅ Impact ÷ Effort
+        effort: effort,                      // low/medium/high
+        cost: effort,                        // cost band key; the Hub renders it as $/$$/$$$
+        score: score,                        // Impact ÷ Effort
         // ── MANAGEMENT RESPONSE STUB (M2) ──
         decision: 'mitigate',                // ✅ minúsculas
         owner: '',

--- a/ui/remediation-hub.html
+++ b/ui/remediation-hub.html
@@ -1342,6 +1342,18 @@ function importHubJSON(input) {
   input.value = '';
 }
 
+/**
+ * Mirrors buildFindingId() in the audit engine so both sides derive an
+ * identical stable id for the same control. Keeping the two formulas in sync
+ * matters because the merge below prefers matching on id.
+ */
+function buildFindingId(control, framework) {
+  const fw = framework || 'nist-csf';
+  const scfId = control.scfId || control.id || '';
+  const key = scfId || `CUSTOM-${control.fwCode || control.name || control.ctrl || 'UNKNOWN'}`;
+  return `FND-${(key + '-' + fw).replace(/[^a-zA-Z0-9]/g, '_').toUpperCase()}`;
+}
+
 function processImportedData(data) {
   let incomingFindings = [];
   if (data.findings && Array.isArray(data.findings) && data.findings.length > 0) {
@@ -1353,7 +1365,7 @@ function processImportedData(data) {
         const severity = c.riesgo || 'medium';
         const days = DEFAULT_TIMEFRAMES[severity.toLowerCase()] || 60;
         return {
-          id: `FND-${(c.scfId || c.id || 'UNKNOWN').toUpperCase().replace(/[^A-Z0-9]/g,'_')}`,
+          id: buildFindingId(c, data.framework),
           scfId: c.scfId || '',
           controlCode: c.fwCode || c.ctrl || '',
           controlName: c.name || '',
@@ -1377,16 +1389,33 @@ function processImportedData(data) {
       });
   }
 
-  // Calculate scores
+  // Normalise incoming findings before anything reads them. data.findings is
+  // taken straight from the imported file, so an older or hand-edited payload
+  // can omit fields the renderers assume exist — a missing timeframe used to
+  // throw and abort the whole import, leaving the Hub blank.
   incomingFindings.forEach(f => {
-    f.score = calculateScore(f);
-    f.effort = f.effort || estimateEffort(f);
-    f.cost = f.cost || f.effort;
+    const sev   = (f.severity || f.riskLevel || 'medium').toLowerCase();
+    f.severity  = sev;
+    f.riskLevel = f.riskLevel || sev;
+    f.effort    = f.effort || estimateEffort(f);
+    f.cost      = f.cost || f.effort;
+    f.score     = calculateScore(f);
+    f.timeframe = f.timeframe || `${DEFAULT_TIMEFRAMES[sev] || 60} days`;
+    f.status    = f.status || 'open';
+    f.decision  = f.decision || 'mitigate';
+    f.history   = Array.isArray(f.history) ? f.history : [];
+    f.createdAt = f.createdAt || Date.now();
+    f.updatedAt = f.updatedAt || Date.now();
   });
 
   const localFindings = JSON.parse(localStorage.getItem('hub_findings') || '[]');
   const mergedFindings = incomingFindings.map(newF => {
-    const existing = localFindings.find(e => e.id === newF.id || e.scfId === newF.scfId);
+    // Match on id first. Only fall back to scfId when it is actually present:
+    // manually added controls carry scfId === '', and an unguarded comparison
+    // would make every such finding match the first one and merge them together.
+    const existing = localFindings.find(e =>
+      e.id === newF.id || (newF.scfId && e.scfId === newF.scfId)
+    );
     if (existing) {
       return {
         ...newF,
@@ -1602,7 +1631,7 @@ function renderMatrixCards(findings, color) {
     const effortIcon = { low: '🟢', medium: '🟡', high: '🔴' }[f.effort] || '';
     const effortLabel = { low: t('effort_low'), medium: t('effort_medium'), high: t('effort_high') }[f.effort] || f.effort;
     const costLabel = COST_LABELS[f.cost] || '$$';
-    const daysMatch = f.timeframe.match(/(\d+)/);
+    const daysMatch = String(f.timeframe || '').match(/(\d+)/);
     const days = daysMatch ? daysMatch[1] : '—';
     
     return `


### PR DESCRIPTION
Follow-up to the M1 finding schema work in #23 / #22. I reviewed the merged M1 implementation against the proposal — it lines up really well, and the priority scoring, matrix and Kanban additions go beyond what we scoped. 👏

These are the issues I found while reviewing, all verified in the browser. Happy to split any of them out or drop them if you'd rather handle them differently.

---

## Engine — `ui/auditnist-local.html`

### 1. The "issued" state only existed in the downloaded file (main one)
`issueFinalReport()` set `data.engagement.status = 'issued'` on the object it downloaded, but never touched the app. The status selector kept its previous value, so:

- the downloaded JSON said `issued`, but the app still showed `in_progress`/`draft`
- the **next Save or Export re-read the selector and wrote the old status back** — the app forgot the audit was ever issued, contradicting a report already sent to the client

This matters beyond cosmetics: **M4 (locking / versioning) needs a durable issued state to key off.** The status is now written back to the selector and persisted to localStorage.

Regression now covered: after issuing, a subsequent `saveProgress()` and `collectAuditData()` both still report `issued`.

### 2. Manually added controls never became findings
`buildFinding()` returned `null` when `scfId` was empty. But `+ Add Control` calls `addControl()` with no arguments, so custom controls carry `scfId === ''` — meaning **a non-compliant custom control silently produced no finding at all**.

The intent (avoiding phantom findings) was right, so I kept it but narrowed it: only controls with *no identity at all* are skipped. Custom controls now fall back to a stable id derived from their code/name (`FND-CUSTOM_...`).

### 3. Dead code / misleading comment
`COST_LABELS` was defined but never used in the engine (the Hub does its own `COST_LABELS[f.cost]` mapping, so behaviour was already correct). Removed it, and fixed the comment on `cost` which claimed `$/$$/$$$` while assigning `low/medium/high`.

---

## Remediation Hub — `ui/remediation-hub.html`

### 4. The two sides derived different IDs
The engine builds `FND-{SCFID}_{FRAMEWORK}`, but the Hub's fallback derive path built `FND-{SCFID}` with no framework suffix — so the two could **never match on `id`**, and only the `|| e.scfId === newF.scfId` fallback kept the merge working. Both sides now share one `buildFindingId()` formula (verified: identical output for the same control).

### 5. Custom findings collided on merge
The merge compared `e.scfId === newF.scfId` unguarded. Every custom finding has `scfId === ''`, so **`'' === ''` matched — every custom finding merged into the first one**, cross-assigning owners/status between unrelated findings. `scfId` is now only compared when actually present.

### 6. A partial `findings[]` payload crashed the whole import
`data.findings` was trusted exactly as imported, and `renderMatrixCards()` called `f.timeframe.match(...)` unguarded — so a hand-edited or older payload missing `timeframe` threw a `TypeError` and **aborted the entire import, leaving the Hub blank**. (Notably the reads at 1575 / 1904 / 2212 all guard this already, so it looked like an oversight.)

Incoming findings are now normalised with safe defaults (`timeframe`, `status`, `decision`, `history`, `severity`, timestamps) before anything renders, and the remaining unguarded read is guarded.

---

## Verification

All checked in the browser against a running server, zero console errors:

- [x] Engine and Hub derive **identical** ids — `FND-SCF_AST_01_NIST_CSF`, `FND-CUSTOM_CUSTOM_01_NIST_CSF`
- [x] Custom control (no scfId) now yields a finding; fully empty control still skipped
- [x] `buildFindingsFromControls` returns 2 findings where it previously returned 1
- [x] After Issue Final Report: selector, localStorage, later Save **and** later Export all report `issued`
- [x] Findings payload missing `timeframe` imports cleanly and defaults to `30 days` for high severity
- [x] Two custom findings keep their own owners (Alice/Bob) instead of collapsing into one
- [x] Timeframes correct: critical 15d / high 30d / medium 60d / low 90d
- [x] M0 lifecycle tests: 17 passed, 0 failed

---

## One design point worth a conscious decision (not changed here)

Findings are now generated on **every** `collectAuditData()` — so every Save/Export includes `findings[]` and `schemaVersion: 3`, even for unpublished drafts. The proposal emitted findings *at publish*. Your approach is simpler and lets the Hub consume drafts, so I left it alone — but it does mean a draft and an issued report look nearly identical apart from `publishedAt`. Worth deciding deliberately before M4 builds locking on top of it.

Let me know what you think — happy to adjust anything here.