### PR TITLE
fix: issuing a report must snapshot findings, not just stamp a date

### DIFF
--- a/ui/auditnist-local.html
+++ b/ui/auditnist-local.html
@@ -1244,6 +1244,7 @@ function loadAuditById(key) {
   document.getElementById('id_informe').value = data.id || '';
   document.getElementById('fecha').value = data.fecha || '';
   applyEngagement(data);  // restores Audit Plan; defaults cleanly for pre-#20 (v1) files
+  applyPublishState(data);  // an already-issued audit stays frozen after reload
 
   const ctrlsContainer = document.getElementById('controls');
   while (ctrlsContainer.firstChild) ctrlsContainer.removeChild(ctrlsContainer.firstChild);
@@ -2091,7 +2092,8 @@ function clearData() {
   ['empresa_auditada','empresa_auditora','auditor','alcance','id_informe','fecha']
     .forEach(id => document.getElementById(id).value = '');
 
-  applyEngagement({});  // reset Audit Plan panel to defaults
+  applyEngagement({});    // reset Audit Plan panel to defaults
+  applyPublishState({});  // a cleared workspace is a fresh draft, not an issued audit
 
   const ctrls = document.getElementById('controls');
   while (ctrls.firstChild) ctrls.removeChild(ctrls.firstChild);
@@ -2199,6 +2201,28 @@ status: val('eng_status') || 'draft'
 };
 }
 
+/**
+ * Publish snapshot.
+ *
+ * Issuing a report has to CAPTURE the findings, not just stamp a date.
+ * collectAuditData() re-derives everything from the DOM, so without a snapshot
+ * an issued audit would lose publishedAt on the next save and its findings
+ * would silently follow any later control edit — quietly contradicting the
+ * report already delivered to the client.
+ *
+ * While the audit is a draft this stays null and findings are derived live
+ * (so the Hub can consume drafts). Once issued, the captured findings and
+ * timestamp are carried forward verbatim. M4 builds the formal
+ * locking/revision flow on top of this.
+ */
+let publishedSnapshot = null;   // { publishedAt, findings } once issued
+
+function applyPublishState(data) {
+  publishedSnapshot = (data && data.publishedAt)
+    ? { publishedAt: data.publishedAt, findings: Array.isArray(data.findings) ? data.findings : [] }
+    : null;
+}
+
 function applyEngagement(data) {
 const eng = (data && data.engagement) || {};
 const set = (id, v) => { const el = document.getElementById(id); if (el) el.value = v || ''; };
@@ -2295,8 +2319,15 @@ function collectAuditData() {
     }
   });
 
-  // 3. Generar findings
-  data.findings = buildFindingsFromControls(data.controls, data.id);
+  // 3. Findings: frozen once the audit has been issued, derived live otherwise.
+  //    Re-deriving here on an issued audit is what let a later control edit
+  //    rewrite findings that had already been reported, and reset publishedAt.
+  if (publishedSnapshot) {
+    data.findings    = publishedSnapshot.findings;
+    data.publishedAt = publishedSnapshot.publishedAt;
+  } else {
+    data.findings = buildFindingsFromControls(data.controls, data.id);
+  }
   return data;
 }
 /**
@@ -2320,9 +2351,15 @@ function collectAuditData() {
  * -------------------------------------------------------------
  */
 function issueFinalReport() {
+  // Derive findings fresh from the current controls at the moment of issue,
+  // ignoring any earlier snapshot (re-issuing must re-capture, not replay).
+  publishedSnapshot = null;
   const data = collectAuditData();
   data.publishedAt = new Date().toISOString();
   data.engagement.status = 'issued';
+
+  // Freeze exactly what was issued so later edits cannot rewrite it.
+  publishedSnapshot = { publishedAt: data.publishedAt, findings: data.findings };
 
   // The issued state must live in the app, not only in the downloaded file.
   // Without this the status selector still reads its previous value, so the
@@ -2528,6 +2565,7 @@ document.getElementById('alcance').value = data.alcance || '';
 document.getElementById('id_informe').value = data.id || '';
 document.getElementById('fecha').value = data.fecha || '';
 applyEngagement(data);  // restores Audit Plan; defaults cleanly for pre-#20 (v1) files
+applyPublishState(data);  // an already-issued audit stays frozen after import
 
 if (data.evaluatedControls) {
 evaluatedControls = data.evaluatedControls;


### PR DESCRIPTION
Follow-up to #25. I raised the "drafts and issued reports look near-identical" point there as a design question for M4 — but on testing it, it turned out to be two real bugs, so fixing rather than deferring.

Also correcting myself from #25: the `schemaVersion: 3` part of that comment was noise (it describes the *format*, not the state), and `publishedAt` already distinguishes draft from issued perfectly well. The actual problem was different.

## The bugs

```
At issue:             status=issued  publishedAt=2026-07-16T16:02  severity=high
Edit a control, Save: status=issued  publishedAt=null ❌           severity=low ❌
```

1. **`publishedAt` was wiped on the next save.** `collectAuditData()` hardcodes `publishedAt: null`, so an issued audit ended up with `status=issued` and no publish date.
2. **Issued findings silently drifted.** Changing a control's risk *after* issuing and hitting Save rewrote the issued finding `high → low` — so the stored audit no longer matched the report already delivered to the client.

(For transparency: persisting `status='issued'` in #25 is what made this visible. Before, the status quietly reverted to `draft`, so the record was at least self-consistent — just wrong.)

## Root cause

**Issuing stamped a date but captured nothing.** `collectAuditData()` re-derives the entire record from the DOM, and publish state doesn't live in the DOM — so by design every save destroyed it. Findings got re-derived from the current controls; `publishedAt` got reset.

## The fix — publish = snapshot

Issuing now captures `publishedAt` **and** the findings into a publish snapshot.

- **Drafts are unchanged** — findings are still derived live on every collect, so the Hub can keep consuming drafts. Your always-generate design is preserved deliberately; it's genuinely useful.
- **Once issued** — the captured findings and timestamp are carried forward verbatim. Controls stay editable and still reflect edits, but they no longer rewrite what was issued.
- The snapshot is restored when an issued audit is loaded or imported, cleared by `clearData()`, and re-issuing re-captures rather than replaying an old snapshot.

This gives **M4 a durable issued state to lock against** — the formal amendment/revision flow drops on top of this rather than needing a snapshot concept retrofitted later.

## Verification (browser, zero console errors)

- [x] **Drafts still live**: editing a control changes the derived finding (`high → critical`), `publishedAt` stays `null`
- [x] **At issue**: `status=issued`, `publishedAt` set, `severity=high` captured
- [x] **The repro is fixed**: after editing a control and saving an issued audit → `publishedAt` **kept**, `severity` **stays `high`** (was `null` / `low`)
- [x] **Controls still track the edit** (`riesgo=low` in `controls[]`) — only the issued findings are frozen
- [x] **Frozen across reload** and re-import of an issued audit
- [x] **`clearData()`** resets to a fresh draft
- [x] M0 lifecycle tests: 17 passed, 0 failed

## Note for M4

Right now an issued audit's `controls[]` can drift from its frozen `findings[]` (edit is recorded, issued record preserved). That's intentional and strictly better than silently rewriting history — but it's exactly the seam where M4 should add "editing an issued audit creates revision 2" and/or a lock prompt. Flagging so it's a deliberate M4 decision rather than a surprise.