### PR TITLE
feat(m2): Management Response — single decision vocabulary + response provenance

### DIFF
--- a/ui/auditnist-local.html
+++ b/ui/auditnist-local.html
@@ -2481,13 +2481,20 @@ function buildFinding(control, auditId) {
         effort: effort,                      // low/medium/high
         cost: effort,                        // cost band key; the Hub renders it as $/$$/$$$
         score: score,                        // Impact ÷ Effort
-        // ── MANAGEMENT RESPONSE STUB (M2) ──
-        decision: 'mitigate',                // ✅ minúsculas
+        // ── MANAGEMENT RESPONSE (M2) ──
+        decision: 'mitigate',                // avoid|mitigate|transfer|risk_accepted|false_positive
         owner: '',
-        timeframe: `${days} days`,           // ✅ Formato "X days"
-        status: 'open',                      // ✅ minúsculas
+        timeframe: `${days} days`,           // "X days"
+        status: 'open',
         notes: '',
-        recommendation: ''
+        recommendation: '',
+        // Provenance of the auditee's response — seeded empty so the shape is
+        // consistent from creation. source stays 'manual_entry' (auditor as
+        // scribe) until an integration feeds responses in.
+        managementResponse: {
+            responder: '', responderRole: '', responseDate: '',
+            receivedVia: '', comments: '', source: 'manual_entry'
+        }
     };
 }
 

--- a/ui/remediation-hub.html
+++ b/ui/remediation-hub.html
@@ -514,6 +514,8 @@ const I18N = {
     ai_copilot: '🤖 AI Remediation Copilot', generate_recommendation: 'Generar Recomendación',
     suggest_evidence: 'Sugerir Evidencia', history: 'Historial de Cambios',
     owner: 'Responsable', deadline: 'Plazo', decision: 'Decisión', status: 'Estado',
+    decision_avoid: 'Evitar', decision_mitigate: 'Mitigar', decision_transfer: 'Transferir', decision_risk_accepted: 'Riesgo Aceptado', decision_false_positive: 'Falso Positivo',
+    mgmt_response: 'Respuesta de la Dirección', responder: 'Responde', responder_role: 'Cargo', response_date: 'Fecha de Respuesta', received_via: 'Recibido por', response_comments: 'Comentarios', source: 'Origen',
     finding: 'Hallazgo', control: 'Control', risk: 'Riesgo', reason: 'Razón',
     days_open: 'días abierto', overdue_label: 'VENCIDO',
     no_findings: 'No hay hallazgos que coincidan con los filtros',
@@ -564,6 +566,8 @@ const I18N = {
     ai_copilot: '🤖 AI Remediation Copilot', generate_recommendation: 'Generate Recommendation',
     suggest_evidence: 'Suggest Evidence', history: 'Change History',
     owner: 'Owner', deadline: 'Deadline', decision: 'Decision', status: 'Status',
+    decision_avoid: 'Avoid', decision_mitigate: 'Mitigate', decision_transfer: 'Transfer', decision_risk_accepted: 'Risk Accepted', decision_false_positive: 'False Positive',
+    mgmt_response: 'Management Response', responder: 'Responder', responder_role: 'Role', response_date: 'Response Date', received_via: 'Received Via', response_comments: 'Comments', source: 'Source',
     finding: 'Finding', control: 'Control', risk: 'Risk', reason: 'Reason',
     days_open: 'days open', overdue_label: 'OVERDUE',
     no_findings: 'No findings match the filters',
@@ -1403,6 +1407,18 @@ function processImportedData(data) {
     f.timeframe = f.timeframe || `${DEFAULT_TIMEFRAMES[sev] || 60} days`;
     f.status    = f.status || 'open';
     f.decision  = f.decision || 'mitigate';
+    // Migrate the legacy 'accept' value (from the old duplicate dropdown) to
+    // the 'risk_accepted' the status enum and Risk Acceptance Form already use.
+    if (f.decision === 'accept') f.decision = 'risk_accepted';
+    // Management-response provenance: who at the audited company responded, and
+    // how it reached us. source stays 'manual_entry' until an integration feeds
+    // responses in; the object is seeded so the detail panel always has a shape.
+    if (!f.managementResponse || typeof f.managementResponse !== 'object') {
+      f.managementResponse = { responder: '', responderRole: '', responseDate: '',
+                               receivedVia: '', comments: '', source: 'manual_entry' };
+    } else {
+      f.managementResponse.source = f.managementResponse.source || 'manual_entry';
+    }
     f.history   = Array.isArray(f.history) ? f.history : [];
     f.createdAt = f.createdAt || Date.now();
     f.updatedAt = f.updatedAt || Date.now();
@@ -1429,6 +1445,9 @@ function processImportedData(data) {
         recommendation: existing.recommendation || '',
         riskAcceptance: existing.riskAcceptance || null,
         compensatingControl: existing.compensatingControl || '',
+        // Preserve the recorded management response across re-imports, exactly
+        // like owner/decision — a re-audit must not wipe who responded.
+        managementResponse: existing.managementResponse || newF.managementResponse,
         createdAt: existing.createdAt || newF.createdAt,
         updatedAt: Date.now()
       };
@@ -2066,31 +2085,53 @@ function renderDetail(id) {
       <div class="grid grid-cols-2 gap-2 mb-4">
         <div>
           <label class="text-[10px] text-slate-400 uppercase">${t('owner')}</label>
-          <input type="text" value="${escapeHTML(f.owner || '')}" onchange="updateFinding('${escapeHTML(f.id)}', 'owner', this.value)" 
+          <input type="text" value="${escapeHTML(f.owner || '')}" onchange="updateFinding('${escapeHTML(f.id)}', 'owner', this.value)"
             class="w-full mt-1 p-1.5 rounded bg-slate-900 border border-slate-600 text-xs focus:border-indigo-400 outline-none">
         </div>
-        <div class="mb-4">
+        <div>
           <label class="text-[10px] text-slate-400 uppercase">${t('decision')}</label>
-          <select onchange="updateFinding('${escapeHTML(f.id)}', 'decision', this.value)" 
+          <select onchange="onDecisionChange('${escapeHTML(f.id)}', this.value)"
             class="w-full mt-1 p-1.5 rounded bg-slate-900 border border-slate-600 text-xs focus:border-indigo-400 outline-none">
-            <option value="avoid" ${f.decision==='avoid'?'selected':''}>🚫 Evitar</option>
-            <option value="mitigate" ${f.decision==='mitigate'?'selected':''}>🛠️ Mitigar</option>
-            <option value="transfer" ${f.decision==='transfer'?'selected':''}>📤 Transferir</option>
-            <option value="accept" ${f.decision==='accept'?'selected':''}>⚠️ Aceptar</option>
-            <option value="false_positive" ${f.decision==='false_positive'?'selected':''}>❌ Falso positivo</option>
+            <option value="avoid" ${f.decision==='avoid'?'selected':''}>🚫 ${t('decision_avoid')}</option>
+            <option value="mitigate" ${f.decision==='mitigate'?'selected':''}>🛠️ ${t('decision_mitigate')}</option>
+            <option value="transfer" ${f.decision==='transfer'?'selected':''}>📤 ${t('decision_transfer')}</option>
+            <option value="risk_accepted" ${f.decision==='risk_accepted'?'selected':''}>⚠️ ${t('decision_risk_accepted')}</option>
+            <option value="false_positive" ${f.decision==='false_positive'?'selected':''}>❌ ${t('decision_false_positive')}</option>
           </select>
         </div>
       </div>
 
-      <div class="mb-4">
-        <label class="text-[10px] text-slate-400 uppercase">${t('decision')}</label>
-        <select onchange="updateFinding('${escapeHTML(f.id)}', 'decision', this.value)" 
-          class="w-full mt-1 p-1.5 rounded bg-slate-900 border border-slate-600 text-xs focus:border-indigo-400 outline-none">
-          <option value="mitigate" ${f.decision==='mitigate'?'selected':''}>🛠️ Mitigate</option>
-          <option value="risk_accepted" ${f.decision==='risk_accepted'?'selected':''}>⚠️ Risk Accepted</option>
-          <option value="false_positive" ${f.decision==='false_positive'?'selected':''}>❌ False Positive</option>
-        </select>
+      ${(() => { const mr = f.managementResponse || {}; return `
+      <div class="mb-4 border border-slate-700 rounded p-2.5 bg-slate-900/40">
+        <p class="text-[10px] text-indigo-300 uppercase tracking-wider mb-2 font-bold">🗣️ ${t('mgmt_response')}</p>
+        <div class="grid grid-cols-2 gap-2 mb-2">
+          <div>
+            <label class="text-[10px] text-slate-400 uppercase">${t('responder')}</label>
+            <input type="text" value="${escapeHTML(mr.responder || '')}" onchange="updateResponseField('${escapeHTML(f.id)}', 'responder', this.value)"
+              class="w-full mt-1 p-1.5 rounded bg-slate-900 border border-slate-600 text-xs focus:border-indigo-400 outline-none">
+          </div>
+          <div>
+            <label class="text-[10px] text-slate-400 uppercase">${t('responder_role')}</label>
+            <input type="text" value="${escapeHTML(mr.responderRole || '')}" onchange="updateResponseField('${escapeHTML(f.id)}', 'responderRole', this.value)"
+              class="w-full mt-1 p-1.5 rounded bg-slate-900 border border-slate-600 text-xs focus:border-indigo-400 outline-none">
+          </div>
+          <div>
+            <label class="text-[10px] text-slate-400 uppercase">${t('response_date')}</label>
+            <input type="date" value="${escapeHTML(mr.responseDate || '')}" onchange="updateResponseField('${escapeHTML(f.id)}', 'responseDate', this.value)"
+              class="w-full mt-1 p-1.5 rounded bg-slate-900 border border-slate-600 text-xs focus:border-indigo-400 outline-none">
+          </div>
+          <div>
+            <label class="text-[10px] text-slate-400 uppercase">${t('received_via')}</label>
+            <input type="text" value="${escapeHTML(mr.receivedVia || '')}" placeholder="email, meeting…" onchange="updateResponseField('${escapeHTML(f.id)}', 'receivedVia', this.value)"
+              class="w-full mt-1 p-1.5 rounded bg-slate-900 border border-slate-600 text-xs focus:border-indigo-400 outline-none">
+          </div>
+        </div>
+        <label class="text-[10px] text-slate-400 uppercase">${t('response_comments')}</label>
+        <textarea rows="2" onchange="updateResponseField('${escapeHTML(f.id)}', 'comments', this.value)"
+          class="w-full mt-1 p-2 rounded bg-slate-900 border border-slate-600 text-xs focus:border-indigo-400 outline-none">${escapeHTML(mr.comments || '')}</textarea>
+        <p class="text-[9px] text-slate-500 mt-1">${t('source')}: ${escapeHTML(mr.source || 'manual_entry')}</p>
       </div>
+      `; })()}
 
       <div class="mb-4">
         <label class="text-[10px] text-slate-400 uppercase">${t('remediation_notes')}</label>
@@ -2190,6 +2231,43 @@ function updateFinding(id, field, value) {
   renderCharts();
   renderPriorityMatrix();
   renderFindings();
+  renderDetail(id);
+}
+
+// Decision changes route through here so choosing "Risk Accepted" forces the
+// formal Risk Acceptance Form (approver + review date) rather than silently
+// accepting a risk with no justification on record.
+function onDecisionChange(id, value) {
+  if (value === 'risk_accepted') {
+    updateFinding(id, 'decision', 'risk_accepted');
+    openRiskModal();
+    return;
+  }
+  updateFinding(id, 'decision', value);
+}
+
+// Writes a field inside the finding's managementResponse object (who at the
+// audited company responded, when, and how it reached us). Kept as its own
+// helper because updateFinding only sets top-level fields. History is logged
+// the same way so provenance edits appear in the timeline.
+function updateResponseField(id, field, value) {
+  const f = state.findings.find(x => x.id === id);
+  if (!f) return;
+  if (!f.managementResponse) f.managementResponse = { source: 'manual_entry' };
+  const mr = f.managementResponse;
+  const oldValue = mr[field];
+  if (oldValue === value) return;
+
+  mr[field] = value;
+  mr.source = mr.source || 'manual_entry';
+  f.updatedAt = Date.now();
+  if (!f.history) f.history = [];
+  f.history.push({
+    ts: Date.now(), actor: 'user', field: 'managementResponse',
+    from: oldValue, to: value, note: `response.${field} updated`
+  });
+
+  saveState();
   renderDetail(id);
 }
 
@@ -2422,7 +2500,8 @@ function generateHubPDF() {
     doc.text('Severity', margin + 80, y + 11);
     doc.text('Control', margin + 130, y + 11);
     doc.text('Owner', margin + 280, y + 11);
-    doc.text('Status', margin + 380, y + 11);
+    doc.text(t('decision'), margin + 380, y + 11);
+    doc.text(t('status'), margin + 460, y + 11);
     doc.text('Days', pageWidth - margin - 30, y + 11);
     y += 20;
 
@@ -2442,13 +2521,30 @@ function generateHubPDF() {
       doc.setFontSize(8);
       doc.text(f.controlCode || f.id, margin + 4, y + 10);
       doc.text(sev.toUpperCase(), margin + 80, y + 10);
-      const ctrlName = (f.controlName || '').substring(0, 40);
+      const ctrlName = (f.controlName || '').substring(0, 34);
       doc.text(ctrlName, margin + 130, y + 10);
       doc.text(f.owner || '—', margin + 280, y + 10);
-      doc.text((f.status || 'open').replace('_', ' '), margin + 380, y + 10);
+      doc.text((f.decision || 'mitigate').replace('_', ' '), margin + 380, y + 10);
+      doc.text((f.status || 'open').replace('_', ' '), margin + 460, y + 10);
       doc.text(String(daysOpen(f)), pageWidth - margin - 30, y + 10);
-      
+
       y += 26;
+
+      // Management-response provenance sub-line: who responded and how it
+      // reached us. Only rendered when a response has actually been recorded,
+      // so most rows stay single-line.
+      const mr = f.managementResponse || {};
+      if (mr.responder || mr.receivedVia || mr.responseDate) {
+        if (y > pageHeight - 60) { doc.addPage(); y = margin; }
+        const who = [mr.responder, mr.responderRole && `(${mr.responderRole})`].filter(Boolean).join(' ');
+        const via = [mr.receivedVia, mr.responseDate].filter(Boolean).join(', ');
+        doc.setTextColor(100, 116, 139);
+        doc.setFontSize(7);
+        doc.text(`↳ ${t('mgmt_response')}: ${who || '—'}${via ? ' · ' + via : ''}`, margin + 12, y + 6);
+        doc.setFontSize(8);
+        doc.setTextColor(30, 41, 59);
+        y += 14;
+      }
     });
 
     const totalPages = doc.internal.getNumberOfPages();


### PR DESCRIPTION
Implements the M2 – Management Response proposal (#27), building on the M1 findings work. Since you hadn't had a chance to weigh in yet, I've kept the debatable calls **reversible and flagged below** — happy to change any of them.

Two parts: fix the live decision-dropdown bug, and add the response provenance the lifecycle needs.

---

## 1. Fixed the conflicting decision dropdowns (Hub)

The finding detail rendered **two** "Decision" selects back to back, both bound to the same field:
- `avoid / mitigate / transfer / accept / false_positive` (hardcoded Spanish)
- `mitigate / risk_accepted / false_positive` (English)

They overwrote each other, and `accept` vs `risk_accepted` are the same concept — so picking "Aceptar" stored `accept`, and the second dropdown then displayed "Mitigate".

**Collapsed to one i18n'd dropdown** using the ISO 27005 treatment set: `avoid | mitigate | transfer | risk_accepted | false_positive`.

**Judgment call (reversible):** I kept **`risk_accepted`**, not `accept`, because the `status` enum and your Risk Acceptance Form already use it — so there's no migration of existing data. Legacy `accept` values are migrated to `risk_accepted` on import. If you'd rather standardise on the ISO term `accept`, it's a small change plus a migration flip.

## 2. Management response provenance (Hub)

The Hub recorded *what* was decided but not *who / when / how* — the piece that makes the auditor-as-scribe flow evidence-able.

New `managementResponse` object on each finding:
```
managementResponse: { responder, responderRole, responseDate, receivedVia, comments, source }
```
- Editable in the detail panel (new "Management Response" section), history-logged like every other change, seeded on import and **preserved across re-imports**.
- **`source`** is `'manual_entry'` today — it's the seam so an email/API integration can later feed the same record with no remodelling (the incremental integration path from our Discord chat).
- Choosing **"Risk Accepted"** now routes through `onDecisionChange()`, which opens your existing Risk Acceptance Form — so a risk can't be accepted with no approver / review date on record.
- **Hub PDF**: added a Decision column and a per-finding management-response sub-line (only when a response exists).
- **i18n**: `decision_avoid` / `decision_transfer` + the response labels added to EN and ES. (Side note: the `decision_*` keys were missing from the EN/ES blocks entirely — only fr/de/pt/ar/zh had them — so the old dropdowns were falling back to hardcoded text. Fixed.)

## 3. Engine

`buildFinding()` seeds an empty `managementResponse` so the shape is consistent from creation and rides through the publish snapshot.

---

## Deliberate deviations from the proposal (want your call)

1. **`riskAcceptance` stays top-level**, not nested under `managementResponse` as #27 sketched. Moving it would ripple through `confirmRiskAcceptance`, the merge, and the display for no functional gain right now. Left it where it works; happy to nest it if you prefer the cleaner shape.
2. **Flat `decision` field kept** (open question 2 in #27). I did not split response-type from treatment — that's an audit-methodology call I think is yours to make. Flat matches your current code and most GRC tools.
3. **Risk Acceptance is *required*** (the form opens automatically on `risk_accepted`) rather than just warned. Easy to soften to a prompt if you'd rather.

## Verification (browser, zero console errors)

- [x] Single decision dropdown, 5 ISO options (was two conflicting ones)
- [x] Legacy `accept` migrates to `risk_accepted` on import
- [x] `managementResponse` seeds on import, edits log history, **survives re-import**
- [x] "Risk Accepted" opens the Risk Acceptance Form
- [x] Hub PDF renders with Decision column + response sub-line
- [x] Engine `buildFinding()` seeds `managementResponse` (source `manual_entry`)
- [x] EN/ES labels resolve; other languages fall back to EN
- [x] M0 lifecycle tests: 17/17

No rush on review — nothing here is load-bearing for you, and every debatable choice above is easy to flip.